### PR TITLE
publicizer - a tool to replace internal and private methods and vars with public for testing purposes

### DIFF
--- a/tools/build/publicizer.py
+++ b/tools/build/publicizer.py
@@ -1,24 +1,30 @@
 #!/usr/bin/env python3
-import fileinput
+
+"""
+Usage: publicizer.py someFile.sol
+
+Replaces
+  uint256 internal /* publicForTesting */ someVar;
+with
+  uint256 public /* modifiedForTest */ someVar;
+
+Also replaces "private" instead of "internal", as long as they're followed by
+/* publicForTesting */
+
+The modified file is printed to stdout.
+
+"""
+
 import re
 import sys
 
-# Usage: publicizer.py someFile.sol
-#
-# Replaces
-#   uint256 internal /* publicForTesting */ someVar;
-# with
-#   uint256 public someVar;
-#
-# Also replaces "private" instead of "internal", as long as they're followed by
-# /* publicForTesting */
-#
-# The modified file is printed to stdout.
-
-p = re.compile('\s+(internal|public)\s*/\*\s*publicForTesting\s*\*/\s*')
-replaceWith = ' public /* modifiedForTest */ '
 
 def substitute(content):
+  """Does the actual substitution"""
+
+  p = re.compile(r'\s+(internal|public)\s*/\*\s*publicForTesting\s*\*/\s*')
+  replaceWith = ' public /* modifiedForTest */ '
+
   return p.sub(replaceWith, content)
 
 if __name__ == "__main__":

--- a/tools/build/publicizer.py
+++ b/tools/build/publicizer.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import fileinput
+import re
+import sys
+
+# Usage: publicizer.py someFile.sol
+#
+# Replaces
+#   uint256 internal /* publicForTesting */ someVar;
+# with
+#   uint256 public someVar;
+#
+# Also replaces "private" instead of "internal", as long as they're followed by
+# /* publicForTesting */
+#
+# The modified file is printed to stdout.
+
+p = re.compile('\s+(internal|public)\s*/\*\s*publicForTesting\s*\*/\s*')
+replaceWith = ' public /* modifiedForTest */ '
+
+def substitute(content):
+  return p.sub(replaceWith, content)
+
+if __name__ == "__main__":
+  with open(sys.argv[1]) as file:
+    print(substitute(file.read()))
+

--- a/tools/build/publicizer.py
+++ b/tools/build/publicizer.py
@@ -3,20 +3,24 @@
 """
 Usage: publicizer.py someFile.sol
 
-Replaces
+Replaces both
   uint256 internal /* publicForTesting */ someVar;
+  and
+  uint256 private /* publicForTesting */ someVar;
 with
   uint256 public /* modifiedForTest */ someVar;
 
-Also replaces "private" instead of "internal", as long as they're followed by
-/* publicForTesting */
-
-The modified file is printed to stdout.
+NOTE: The original file f is backed up to f.backup.<current time> and is overwritten
+with the modified file.
 
 """
 
+import math
 import re
+from shutil import copyfile
 import sys
+import time
+
 
 
 def substitute(content):
@@ -25,9 +29,14 @@ def substitute(content):
   p = re.compile(r'\s+(internal|public)\s*/\*\s*publicForTesting\s*\*/\s*')
   replaceWith = ' public /* modifiedForTest */ '
 
-  return p.sub(replaceWith, content)
+  replacedContent =  p.sub(replaceWith, content)
+  return replacedContent
 
 if __name__ == "__main__":
-  with open(sys.argv[1]) as file:
-    print(substitute(file.read()))
+  currentTime = math.floor(time.time())
+  copyfile(sys.argv[1], sys.argv[1] + ".backup." + str(currentTime))
+  with open(sys.argv[1], "r+") as file:
+    newcontent = substitute(file.read())
+    file.seek(0)
+    file.write(newcontent)
 

--- a/tools/build/publicizer_test.py
+++ b/tools/build/publicizer_test.py
@@ -1,47 +1,50 @@
 #!/usr/bin/env python3
 
+"""
+Unit test for publicizer.py
+"""
+
 import unittest
 import publicizer as p
 
-
 class PublicizerTest(unittest.TestCase):
 
-    # Helpers
-    def assertPublicized(self, expected, source):
-      self.assertEqual(expected, p.substitute(source))
+  # Helpers
+  def assert_publicized(self, expected, source):
+    self.assertEqual(expected, p.substitute(source))
 
-    def assertNotPublicized(self, source):
-      self.assertEqual(source, p.substitute(source))
+  def assert_not_publicized(self, source):
+    self.assertEqual(source, p.substitute(source))
 
-    # Tests
-    def testDoesNotPublicizeIrrelevantStrings(self):
-      self.assertNotPublicized("nothing")
+  # Tests
+  def test_ignores_unrelated_strings(self):
+    self.assert_not_publicized("nothing")
 
-    def testDoesNotPublicizeIrrelevantMultilineStrings(self):
-      self.assertNotPublicized("line1\n line2\n")
+  def test_ignores_unrelated_multiline_strings(self):
+    self.assert_not_publicized("line1\n line2\n")
 
-    def testEmptyString(self):
-      self.assertNotPublicized("")
+  def test_empty_string(self):
+    self.assert_not_publicized("")
 
-    def testChangesInternalToPublic(self):
-      self.assertPublicized(
+  def test_changes_internal_to_public(self):
+    self.assert_publicized(
         "uint256 public /* modifiedForTest */ x;",
         "uint256 internal /* publicForTesting */ x;")
 
-    def testChangesPrivateToPublic(self):
-      self.assertPublicized(
+  def test_changes_private_to_public(self):
+    self.assert_publicized(
         "uint256 public /* modifiedForTest */ x;",
         "uint256 internal /* publicForTesting */ x;")
 
-    def testDoesNotChangeOtherModifiers(self):
-      self.assertNotPublicized(
+  def test_does_not_change_other_modifiers(self):
+    self.assert_not_publicized(
         "uint256 external /* publicForTesting */ x;")
 
-    def testEatsWhitespace(self):
-      self.assertPublicized(
+  def test_eats_whitespace(self):
+    self.assert_publicized(
         "uint256 public /* modifiedForTest */ y;",
         "uint256   \n internal   /*   publicForTesting    */ y;")
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()
 

--- a/tools/build/publicizer_test.py
+++ b/tools/build/publicizer_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import unittest
+import publicizer as p
+
+
+class PublicizerTest(unittest.TestCase):
+
+    # Helpers
+    def assertPublicized(self, expected, source):
+      self.assertEqual(expected, p.substitute(source))
+
+    def assertNotPublicized(self, source):
+      self.assertEqual(source, p.substitute(source))
+
+    # Tests
+    def testDoesNotPublicizeIrrelevantStrings(self):
+      self.assertNotPublicized("nothing")
+
+    def testDoesNotPublicizeIrrelevantMultilineStrings(self):
+      self.assertNotPublicized("line1\n line2\n")
+
+    def testEmptyString(self):
+      self.assertNotPublicized("")
+
+    def testChangesInternalToPublic(self):
+      self.assertPublicized(
+        "uint256 public /* modifiedForTest */ x;",
+        "uint256 internal /* publicForTesting */ x;")
+
+    def testChangesPrivateToPublic(self):
+      self.assertPublicized(
+        "uint256 public /* modifiedForTest */ x;",
+        "uint256 internal /* publicForTesting */ x;")
+
+    def testDoesNotChangeOtherModifiers(self):
+      self.assertNotPublicized(
+        "uint256 external /* publicForTesting */ x;")
+
+    def testEatsWhitespace(self):
+      self.assertPublicized(
+        "uint256 public /* modifiedForTest */ y;",
+        "uint256   \n internal   /*   publicForTesting    */ y;")
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Related to our previous discussion, the new tool "publicizer" replaces
```  uint256 internal /* publicForTesting */ someVar;```
with
```  uint256 public /* modifiedForTest */ someVar;```

This is useful to let tests gain access to internal state variables and methods of the production contract.

We could have replaced every single instance of "internal" or "private" with "public" but this takes a more conservative approach where we specify explicitly the vars and functions we want to change, and we mark them also in the test contract.

**Usage**:
```publicizer.py contract.sol > contract_test.sol```

It would be nice later on to integrate it directly into ```truffle test```.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wetrustplatform/rosca-contracts/11)
<!-- Reviewable:end -->
