### PR TITLE
Address audit part 1

### DIFF
--- a/contracts/ROSCA.sol
+++ b/contracts/ROSCA.sol
@@ -42,17 +42,17 @@ contract ROSCA {
   /////////
   // EVENTS
   /////////
-  event LogContributionMade(address user, uint256 amount, uint256 currentRound);
+  event LogContributionMade(address indexed user, uint256 amount, uint256 currentRound);
   event LogStartOfRound(uint256 currentRound);
-  event LogBidSurpassed(uint256 prevBid, address prevWinnerAddress, uint256 currentRound);
-  event LogNewLowestBid(uint256 bid, address winnerAddress, uint256 currentRound);
-  event LogRoundFundsReleased(address winnerAddress, uint256 amount, uint256 roundDiscount, uint256 currentRound);
-  event LogFundsWithdrawal(address user, uint256 amount, uint256 currentRound);
+  event LogBidSurpassed(uint256 prevBid, address indexed prevWinnerAddress, uint256 currentRound);
+  event LogNewLowestBid(uint256 bid, address indexed winnerAddress, uint256 currentRound);
+  event LogRoundFundsReleased(address indexed winnerAddress, uint256 amount, uint256 roundDiscount, uint256 currentRound);
+  event LogFundsWithdrawal(address indexed user, uint256 amount, uint256 currentRound);
   // Fired when withdrawer is entitled for a larger amount than the contract
   // actually holds (excluding fees). A LogFundsWithdrawal will follow
   // this event with the actual amount released, if send() is successful.
-  event LogCannotWithdrawFully(uint256 creditAmount, uint256 currentRound);
-  event LogUnsuccessfulBid(address bidder, uint256 bid, uint256 lowestBid, uint256 currentRound);
+  event LogCannotWithdrawFully(address indexed user, uint256 creditAmount, uint256 currentRound);
+  event LogUnsuccessfulBid(address indexed bidder, uint256 bid, uint256 lowestBid, uint256 currentRound);
   event LogEndOfROSCA();
   event LogForepersonSurplusWithdrawal(uint256 amount);
   event LogFeesWithdrawal(uint256 amount);
@@ -223,7 +223,7 @@ contract ROSCA {
     * Priority is given to non-delinquent participants.
     */
   function startRound() onlyIfRoscaNotEnded external {
-    uint256 roundStartTime = SafeMath.add(startTime, (SafeMath.mul(uint(currentRound), roundPeriodInSecs)));
+    uint256 roundStartTime = SafeMath.add(startTime, (SafeMath.mul(currentRound, roundPeriodInSecs)));
     require(now >= roundStartTime ); // too early to start a new round.
 
     if (currentRound != 0) {
@@ -482,7 +482,7 @@ contract ROSCA {
 
     if (amountAvailable < amountToWithdraw) {
       // This may happen if some participants are delinquent.
-      LogCannotWithdrawFully(amountToWithdraw, currentRound);
+      LogCannotWithdrawFully(msg.sender, amountToWithdraw, currentRound);
       amountToWithdraw = amountAvailable;
     }
     members[msg.sender].credit -= amountToWithdraw;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wetrust-rosca-contract",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "ROSCA contract for Ethereum",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wetrust-rosca-contract",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "description": "ROSCA contract for Ethereum",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
- Line 45,49,50,55: parameters user, winnerAddress, user and bidder  should probably be indexed.
- Line 54: probably, the address of the user who tried to withdraw should be included into LogCannotWithdrawFully event as an indexed parameter.
- Line 226: the cast uint looks redundant. Solidity will automatically case uint16 to uint256 here.

closes #186 