### PR TITLE
Address Audit #3 + fix tests + refactor userTotalCredit

### DIFF
--- a/contracts/ROSCA.sol
+++ b/contracts/ROSCA.sol
@@ -275,7 +275,7 @@ contract ROSCA {
     }
     uint256 currentRoundTotalDiscounts = removeFees(potSize() - lowestBid);
     uint256 roundDiscount = currentRoundTotalDiscounts / membersAddresses.length;
-    totalDiscounts += roundDiscount;
+    totalDiscounts += currentRoundTotalDiscounts;
     members[winnerAddress].credit += removeFees(lowestBid);
     members[winnerAddress].paid = true;
     LogRoundFundsReleased(winnerAddress, lowestBid, roundDiscount, currentRound);
@@ -299,7 +299,7 @@ contract ROSCA {
       address candidate = membersAddresses[index];
       if (!members[candidate].paid) {
         winnerIndex = index;
-        if (members[candidate].credit + totalDiscounts >= requiredContribution()) {
+        if (members[candidate].credit + userDiscounts() >= requiredContribution()) {
           // We found a non-delinquent winner.
           winnerAddress = candidate;
           break;
@@ -336,8 +336,8 @@ contract ROSCA {
         // they could not bid), to correctly calculate their delinquency.
         debit = SafeMath.add(debit, removeFees(potSize()));
       }
-      if (credit + totalDiscounts < debit) {
-        grossTotalFees = SafeMath.sub(grossTotalFees, (debit - credit - totalDiscounts));
+      if (credit + userDiscounts() < debit) {
+        grossTotalFees = SafeMath.sub(grossTotalFees, (debit - credit - userDiscounts()));
       }
     }
 
@@ -408,7 +408,7 @@ contract ROSCA {
       // so we check whether their credit w/o that winning is non-delinquent.
       // check that credit must defaultPot (when debt is set to true, defaultPot was added to credit as winnings) +
       // currentRound in order to be out of debt
-      if (SafeMath.sub(member.credit + totalDiscounts, removeFees(potSize())) >= requiredContribution()) {
+      if (SafeMath.sub(member.credit + userDiscounts(), removeFees(potSize())) >= requiredContribution()) {
           member.debt = false;
       }
     }
@@ -429,7 +429,7 @@ contract ROSCA {
     require(!members[msg.sender].paid  &&
         currentRound != 0 &&  // ROSCA hasn't started yet
         // participant not in good standing
-        members[msg.sender].credit + totalDiscounts >= requiredContribution() &&
+        members[msg.sender].credit + userDiscounts() >= requiredContribution() &&
         // bid is less than minimum allowed
         bid >= SafeMath.mul(potSize(), MIN_DISTRIBUTION_PERCENT) / 100);
 
@@ -470,7 +470,7 @@ contract ROSCA {
   function withdraw() onlyFromMember onlyIfEscapeHatchInactive nonReentrant external returns(bool success) {
     require (!members[msg.sender].debt || endOfROSCA); // delinquent winners need to first pay their debt
 
-    uint256 totalCredit = members[msg.sender].credit + totalDiscounts;
+    uint256 totalCredit = members[msg.sender].credit + userDiscounts();
 
     uint256 totalDebit = members[msg.sender].debt
         ? removeFees(potSize())  // this must be end of rosca
@@ -502,7 +502,7 @@ contract ROSCA {
    * @return int256
    */
   function getParticipantBalance(address user) onlyFromMember external constant returns(int256) {
-    int256 totalCredit = int256(members[user].credit + totalDiscounts);
+    int256 totalCredit = int256(members[user].credit + userDiscounts());
 
     // if rosca have ended, we don't need to subtract as totalDebit should equal to default winnings
     if (members[user].debt && !endOfROSCA) {
@@ -614,6 +614,15 @@ contract ROSCA {
 	////////////////////
 	// HELPER FUNCTIONS
 	////////////////////
+
+
+	/**
+	 * @dev calculates the user's discount amount from the total discount
+	 * @return uint256
+	 */
+	function userDiscounts() internal constant returns (uint256) {
+		return totalDiscounts / membersAddresses.length;
+	}
 
 	/**
    * @dev calculates the default amount user can win in a round

--- a/contracts/ROSCA.sol
+++ b/contracts/ROSCA.sol
@@ -85,7 +85,7 @@ contract ROSCA {
   bool public endOfROSCA = false;
   bool public forepersonSurplusCollected = false;
   // A discount is the difference between a winning bid and the pot value. totalDiscounts is the amount
-  // of discounts accumulated so far, divided by the number of ROSCA participants.
+  // of discounts accumulated so far
   uint256 public totalDiscounts = 0;
 
   // Amount of fees reserved in the contract for fees.

--- a/contracts/ROSCA.sol
+++ b/contracts/ROSCA.sol
@@ -611,20 +611,20 @@ contract ROSCA {
     selfdestruct(foreperson);
   }
 
-	////////////////////
-	// HELPER FUNCTIONS
-	////////////////////
+  ////////////////////
+  // HELPER FUNCTIONS
+  ////////////////////
 
 
-	/**
-	 * @dev calculates the user's discount amount from the total discount
-	 * @return uint256
-	 */
-	function userTotalCredit(address memberAddress) internal constant returns (uint256) {
+  /**
+   * @dev calculates the user's discount amount from the total discount
+   * @return uint256
+   */
+  function userTotalCredit(address memberAddress) internal constant returns (uint256) {
     uint256 userDiscount = totalDiscounts / membersAddresses.length;
 
-		return SafeMath.add(members[memberAddress].credit, userDiscount);
-	}
+  	return SafeMath.add(members[memberAddress].credit, userDiscount);
+  }
 
 	/**
    * @dev calculates the default amount user can win in a round

--- a/contracts/ROSCA.sol
+++ b/contracts/ROSCA.sol
@@ -621,7 +621,9 @@ contract ROSCA {
 	 * @return uint256
 	 */
 	function userTotalCredit(address memberAddress) internal constant returns (uint256) {
-		return members[memberAddress].credit + (totalDiscounts / membersAddresses.length);
+    uint256 userDiscount = totalDiscounts / membersAddresses.length;
+
+		return SafeMath.add(members[memberAddress].credit, userDiscount);
 	}
 
 	/**

--- a/contracts/ROSCA.sol
+++ b/contracts/ROSCA.sol
@@ -623,7 +623,7 @@ contract ROSCA {
   function userTotalCredit(address memberAddress) internal constant returns (uint256) {
     uint256 userDiscount = totalDiscounts / membersAddresses.length;
 
-  	return SafeMath.add(members[memberAddress].credit, userDiscount);
+    return SafeMath.add(members[memberAddress].credit, userDiscount);
   }
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wetrust-rosca-contract",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ROSCA contract for Ethereum",
   "main": "index.js",
   "directories": {

--- a/test/cleanUpPreviousRoundUnitTest.js
+++ b/test/cleanUpPreviousRoundUnitTest.js
@@ -29,8 +29,7 @@ contract('ROSCA cleanUpPreviousRound Unit Test', function(accounts) {
         yield roscaHelper.cleanUpPreviousRound();
 
         let discount = yield roscaHelper.totalDiscounts();
-        const expectedDiscount = utils.afterFee(consts.defaultPot() - BID_TO_PLACE, consts.SERVICE_FEE_IN_THOUSANDTHS)
-          / consts.memberCount();
+        const expectedDiscount = utils.afterFee(consts.defaultPot() - BID_TO_PLACE, consts.SERVICE_FEE_IN_THOUSANDTHS);
 
         assert.equal(discount, expectedDiscount, "toalDiscount value didn't get added properly");
     }));

--- a/test/getBalanceUnitTest.js
+++ b/test/getBalanceUnitTest.js
@@ -37,8 +37,10 @@ contract('ROSCA getParticipantBalance Unit Test', function(accounts) {
 
         let totalDiscounts = yield roscaHelper.totalDiscounts();
 
+        let userDiscount = totalDiscounts / consts.memberCount();
+
         // expected = Pot Won * Fee - next Round contribution
-        let expectedBalance = utils.afterFee(consts.defaultPot() * 0.98) - consts.CONTRIBUTION_SIZE + totalDiscounts;
+        let expectedBalance = utils.afterFee(consts.defaultPot() * 0.98) - consts.CONTRIBUTION_SIZE + userDiscount;
         assert.equal(balance, expectedBalance);
 
         // expectedBalance is Pot won - nextRound contribution (contributionSize + totalDiscount)

--- a/test/utils/roscaHelper.js
+++ b/test/utils/roscaHelper.js
@@ -173,7 +173,7 @@ roscaHelper.prototype.getContractStatus = co(function* (optRosca) {
   return {
     credits: [
       memberInfos[0], memberInfos[1], memberInfos[2], memberInfos[3]],
-    totalDiscounts: results[0].toNumber(),
+    totalDiscounts: results[0].toNumber() / consts.memberCount(),
     currentRound: results[1].toNumber(),
     balance: balance,
     totalFees: results[2].toNumber(),


### PR DESCRIPTION
- Line 302: due to the accumulated errors in totalDiscounts >= it may evaluate to false even if the member already came out of the debt.
- Line 473: in case of using totalDiscounts, due to the accumulated errors, members will be able to withdraw less than they should be able to.

close #184
  
  