### PR TITLE
use node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - "10"
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "truffle": "3.4.11"
   },
   "engines": {
-    "node": "10",
+    "node": "10"
   },
   "scripts": {
     "test": "./tools/build/run-testrpc-and-tests.sh"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "scrypt": "^6.0.3",
     "truffle": "3.4.11"
   },
+  "engines": {
+    "node": "10",
+  },
   "scripts": {
     "test": "./tools/build/run-testrpc-and-tests.sh"
   },


### PR DESCRIPTION
Node 12 is just released and it causes travis build to fail. 
So, we lock it down to node 10.